### PR TITLE
Fix/#155 filter after resuming activity

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
@@ -130,6 +130,7 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener {
             setupPreviewImage(mIsInPhotoMode)
             scheduleFadeOut()
             mFocusCircleView.setStrokeColor(getAdjustedPrimaryColor())
+            mPreview?.previewFilter(0) // reset the filter to default on resume
 
             if (mIsVideoCaptureIntent && mIsInPhotoMode) {
                 handleTogglePhotoVideo()

--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
@@ -130,7 +130,7 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener {
             setupPreviewImage(mIsInPhotoMode)
             scheduleFadeOut()
             mFocusCircleView.setStrokeColor(getAdjustedPrimaryColor())
-            mPreview?.previewFilter(0) // reset the filter to default on resume
+            mPreview?.previewFilter(mPreview?.getFilterIndex()!!)
 
             if (mIsVideoCaptureIntent && mIsInPhotoMode) {
                 handleTogglePhotoVideo()

--- a/app/src/main/kotlin/com/simplemobiletools/camera/interfaces/MyPreview.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/interfaces/MyPreview.kt
@@ -38,4 +38,5 @@ interface MyPreview {
     fun previewFilter(index: Int): Boolean
 
     fun getAvailableFilters(): IntArray
-    }
+    fun getFilterIndex(): Int
+}

--- a/app/src/main/kotlin/com/simplemobiletools/camera/views/CameraPreview.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/views/CameraPreview.kt
@@ -1010,6 +1010,10 @@ class CameraPreview : ViewGroup, TextureView.SurfaceTextureListener, MyPreview {
         }
     }
 
+    override fun getFilterIndex(): Int {
+        return mCurrentFilterIndex
+    }
+
     override fun getAvailableFilters(): IntArray {
 
         val characteristics = this.getCameraCharacteristics()


### PR DESCRIPTION
Bugfix for #155 

Now, when you set a filter, and navigate to another activity, e.g. settings, and come back, the filter should still be there and applied to the taken photo as well