### PR TITLE
Test/unit test #128

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
@@ -36,7 +36,6 @@ import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.content.Context
 import android.graphics.Color
-import android.graphics.Paint
 
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -1158,19 +1157,18 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener {
         displayCaption()
     }
 
-     internal fun getCaptionStamper(): CaptionStamper{
-        if(mCaptionStamper != null){
+    internal fun getCaptionStamper(): CaptionStamper {
+        if (mCaptionStamper != null) {
             return mCaptionStamper
-        }
+            }
 
-        return CaptionStamper()
-    }
+        return CaptionStamper() }
 
-    internal fun setCaptionStamper(s: CaptionStamper){
+    internal fun setCaptionStamper(s: CaptionStamper) {
         mCaptionStamper = s
     }
 
-    internal fun setCameraPreview(c: CameraPreview){
+    internal fun setCameraPreview(c: CameraPreview) {
         mPreview = c
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/camera/activities/MainActivity.kt
@@ -36,6 +36,7 @@ import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.content.Context
 import android.graphics.Color
+import android.graphics.Paint
 
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -1126,7 +1127,7 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener {
             caption_stamp.beVisible()
             shutter.beInvisible()
 
-            mCaptionStamper = CaptionStamper()
+            mCaptionStamper = getCaptionStamper()
             mCaptionStamper.showKeyboard()
         } else {
             caption_holder.beGone()
@@ -1155,5 +1156,21 @@ class MainActivity : SimpleActivity(), PhotoProcessor.MediaSavedListener {
         toggleCaptionFade()
         checkCaptionMode()
         displayCaption()
+    }
+
+     internal fun getCaptionStamper(): CaptionStamper{
+        if(mCaptionStamper != null){
+            return mCaptionStamper
+        }
+
+        return CaptionStamper()
+    }
+
+    internal fun setCaptionStamper(s: CaptionStamper){
+        mCaptionStamper = s
+    }
+
+    internal fun setCameraPreview(c: CameraPreview){
+        mPreview = c
     }
 }

--- a/app/src/test/kotlin/StampUnitTest.kt
+++ b/app/src/test/kotlin/StampUnitTest.kt
@@ -10,35 +10,32 @@ import com.simplemobiletools.camera.implementations.CaptionStamper
 import com.simplemobiletools.commons.extensions.isVisible
 import org.junit.* // ktlint-disable no-wildcard-imports
 
-
 @RunWith(RobolectricTestRunner::class)
 class StampUnitTest : KotlinRobolectric() {
 
     @Test
     fun stampTest() {
-        //Mocks
+        // Mocks
         var mockCaptionStamper = mock<CaptionStamper>()
 
         // Add Mocks
         mMainActivity?.setCaptionStamper(mockCaptionStamper)
 
-        //Check initial value of caption stamp
+        // Check initial value of caption stamp
         Assert.assertEquals(true, mMainActivity?.findViewById<TextView>(R.id.caption_toggle)?.isVisible())
         Assert.assertEquals(false, mMainActivity?.findViewById<TextView>(R.id.caption_stamp)?.isVisible())
         Assert.assertEquals("", mMainActivity?.findViewById<TextView>(R.id.caption_input)?.text.toString())
 
-        //Toggle the stamp
+        // Toggle the stamp
         mMainActivity?.findViewById<TextView>(R.id.caption_toggle)?.performClick()
 
-        //Set stamp text
+        // Set stamp text
         mMainActivity?.findViewById<TextView>(R.id.caption_input)?.text = "Caption Test"
         Assert.assertEquals("Caption Test", mMainActivity?.findViewById<TextView>(R.id.caption_input)?.text.toString())
 
-        //Capture stamp
+        // Capture stamp
         mMainActivity?.findViewById<TextView>(R.id.caption_stamp)?.performClick()
 
-
         verify(mMainActivity?.mCaptionStamper)?.performStamp("Caption Test")
-
     }
 }

--- a/app/src/test/kotlin/StampUnitTest.kt
+++ b/app/src/test/kotlin/StampUnitTest.kt
@@ -1,0 +1,44 @@
+package test.kotlin
+
+import android.widget.TextView
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.simplemobiletools.camera.R
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import com.simplemobiletools.camera.implementations.CaptionStamper
+import com.simplemobiletools.commons.extensions.isVisible
+import org.junit.* // ktlint-disable no-wildcard-imports
+
+
+@RunWith(RobolectricTestRunner::class)
+class StampUnitTest : KotlinRobolectric() {
+
+    @Test
+    fun stampTest() {
+        //Mocks
+        var mockCaptionStamper = mock<CaptionStamper>()
+
+        // Add Mocks
+        mMainActivity?.setCaptionStamper(mockCaptionStamper)
+
+        //Check initial value of caption stamp
+        Assert.assertEquals(true, mMainActivity?.findViewById<TextView>(R.id.caption_toggle)?.isVisible())
+        Assert.assertEquals(false, mMainActivity?.findViewById<TextView>(R.id.caption_stamp)?.isVisible())
+        Assert.assertEquals("", mMainActivity?.findViewById<TextView>(R.id.caption_input)?.text.toString())
+
+        //Toggle the stamp
+        mMainActivity?.findViewById<TextView>(R.id.caption_toggle)?.performClick()
+
+        //Set stamp text
+        mMainActivity?.findViewById<TextView>(R.id.caption_input)?.text = "Caption Test"
+        Assert.assertEquals("Caption Test", mMainActivity?.findViewById<TextView>(R.id.caption_input)?.text.toString())
+
+        //Capture stamp
+        mMainActivity?.findViewById<TextView>(R.id.caption_stamp)?.performClick()
+
+
+        verify(mMainActivity?.mCaptionStamper)?.performStamp("Caption Test")
+
+    }
+}

--- a/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Simple Unit test to test caption stamp. A lot of the methods are static, thus cannot be fully tested using mocks. The code tests the interaction of the caption input and making sure on a click that the caption text will be used in order to stamp the photo. Some modification to @aa-software2112 code was done in order to allow using a mock CaptionStamp() for testing purposes.

When the feature was merged, the PR would not refresh, in order to limit errors, I redid the PR.
None of the code has changed*